### PR TITLE
Error for missing env vars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jakesidsmith/tsb",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jakesidsmith/tsb",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Dead simple TypeScript bundler, watcher, dev server, transpiler, and polyfiller",
   "publishConfig": {
     "access": "public"

--- a/src/config.ts
+++ b/src/config.ts
@@ -149,6 +149,25 @@ export const getTsbConfig = (configPath: string): Config => {
 
   const { default: config } = sandbox.exports;
 
+  if (config.env) {
+    const missingEnvVars = Object.entries(config.env)
+      .map(([key, value]) =>
+        typeof value === 'undefined' && typeof process.env[key] === 'undefined'
+          ? key
+          : null
+      )
+      .filter((key) => key !== null);
+
+    if (missingEnvVars.length) {
+      missingEnvVars.forEach((envVar) => {
+        logger.error(
+          `Could not get value for environment variable "${envVar}"`
+        );
+      });
+      return process.exit(1);
+    }
+  }
+
   if (config.indexHTMLPath) {
     const fullIndexHTMLPath = path.resolve(fullConfigDir, config.indexHTMLPath);
 


### PR DESCRIPTION
Turns out erroring when an env var is missing was only added in webpack 5, and since I'm not ready to update to v5 yet, I've just implemented it myself.