### PR TITLE
Extend webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ interface Config {
   headers?: Record<string, string>;
   // Extend the babel presets
   extendBabelPresets?: (
-    presets: readonly BabelPluginItem[],
+    presets: BabelPluginItem[],
     mode: Mode,
     command: Command
   ) => BabelPluginItem[];
@@ -220,16 +220,16 @@ interface Config {
     plugins: BabelPluginItem[],
     mode: Mode,
     command: Command
-  ) => readonly BabelPluginItem[];
+  ) => BabelPluginItem[];
   // Extend the webpack plugins
   extendWebpackPlugins?: (
-    plugins: readonly WebpackPlugin[],
+    plugins: WebpackPlugin[],
     mode: Mode,
     command: Command
   ) => WebpackPlugin[];
   // Extend the webpack module.rules
   extendWebpackModuleRules?: (
-    rules: readonly WebpackModuleRule[],
+    rules: WebpackModuleRule[],
     mode: Mode,
     command: Command
   ) => WebpackModuleRule[];

--- a/README.md
+++ b/README.md
@@ -209,6 +209,30 @@ interface Config {
   singlePageApp?: boolean; // Default: true
   // Custom headers to send with dev server requests
   headers?: Record<string, string>;
+  // Extend the babel presets
+  extendBabelPresets?: (
+    presets: readonly BabelPluginItem[],
+    mode: Mode,
+    command: Command
+  ) => readonly BabelPluginItem[];
+  // Extend the babel plugins
+  extendBabelPlugins?: (
+    plugins: readonly BabelPluginItem[],
+    mode: Mode,
+    command: Command
+  ) => readonly BabelPluginItem[];
+  // Extend the webpack plugins
+  extendWebpackPlugins?: (
+    plugins: readonly WebpackPlugin[],
+    mode: Mode,
+    command: Command
+  ) => readonly WebpackPlugin[];
+  // Extend the webpack module.rules
+  extendWebpackModuleRules?: (
+    rules: readonly WebpackModuleRule[],
+    mode: Mode,
+    command: Command
+  ) => readonly WebpackModuleRule[];
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,33 @@ export default hot(App);
 
 More info here: https://github.com/gaearon/react-hot-loader
 
+React hot-loading is currently implemented with [react-hot-loader](https://github.com/gaearon/react-hot-loader) and only supports React <= 16. If you want to support React 17 you can use the experimental [@pmmmwh/react-refresh-webpack-plugin](https://github.com/pmmmwh/react-refresh-webpack-plugin) with the `extendBabelPlugins` and `extendWebpackPlugins` options. You should not enable `reactHotLoading` if you are using `react-refresh`.
+
+Example with `react-refresh`:
+
+```ts
+import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
+
+const config: Config = {
+  // ...base config...
+  reactHotLoading: false,
+  extendBabelPlugins: (plugins, mode, command) => {
+    if (command === 'serve') {
+      return [...plugins, require.resolve('react-refresh/babel')];
+    }
+
+    return plugins;
+  },
+  extendWebpackPlugins: (plugins, mode, command) => {
+    if (command === 'serve') {
+      return [...plugins, new ReactRefreshWebpackPlugin()];
+    }
+
+    return plugins;
+  },
+};
+```
+
 ## Dev server
 
 By default the dev server will create an `index.html` file for you and serve this.

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ tsconfig.json
 ```
 
 ```ts
-import { Config } from '../src';
+import { Config } from '@jakesidsmith/tsb';
 
 const config: Config = {
-  main: 'src/index.tsx,
+  main: 'src/index.tsx',
   outDir: 'build',
 };
 

--- a/README.md
+++ b/README.md
@@ -214,10 +214,10 @@ interface Config {
     presets: readonly BabelPluginItem[],
     mode: Mode,
     command: Command
-  ) => readonly BabelPluginItem[];
+  ) => BabelPluginItem[];
   // Extend the babel plugins
   extendBabelPlugins?: (
-    plugins: readonly BabelPluginItem[],
+    plugins: BabelPluginItem[],
     mode: Mode,
     command: Command
   ) => readonly BabelPluginItem[];
@@ -226,13 +226,13 @@ interface Config {
     plugins: readonly WebpackPlugin[],
     mode: Mode,
     command: Command
-  ) => readonly WebpackPlugin[];
+  ) => WebpackPlugin[];
   // Extend the webpack module.rules
   extendWebpackModuleRules?: (
     rules: readonly WebpackModuleRule[],
     mode: Mode,
     command: Command
-  ) => readonly WebpackModuleRule[];
+  ) => WebpackModuleRule[];
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@babel/core": "^7.12.7",
         "@babel/preset-env": "^7.12.7",
+        "@types/babel__core": "^7.1.14",
         "@types/semver": "^7.3.4",
         "@types/webpack-dev-server": "^3.11.1",
         "babel-loader": "^8.2.1",
@@ -1124,6 +1125,43 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA=="
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.1.14",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
+      "integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+      "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+      "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
+      "integrity": "sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==",
+      "dependencies": {
+        "@babel/types": "^7.3.0"
+      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.0",
@@ -10402,6 +10440,43 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA=="
+    },
+    "@types/babel__core": {
+      "version": "7.1.14",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
+      "integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+      "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+      "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
+      "integrity": "sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==",
+      "requires": {
+        "@babel/types": "^7.3.0"
+      }
     },
     "@types/body-parser": {
       "version": "1.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
       },
       "devDependencies": {
         "@hot-loader/react-dom": "^16.14.0",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
         "@types/node": "^12.19.6",
         "@types/react": "^16.14.2",
         "@types/react-dom": "^16.9.10",
@@ -1074,6 +1075,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@hot-loader/react-dom": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-16.14.0.tgz",
@@ -1117,6 +1127,62 @@
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
       },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
+      "integrity": "sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-html": "^0.0.7",
+        "error-stack-parser": "^2.0.6",
+        "html-entities": "^1.2.1",
+        "native-url": "^0.2.6",
+        "schema-utils": "^2.6.5",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">= 10.x"
+      },
+      "peerDependencies": {
+        "@types/webpack": "4.x",
+        "react-refresh": ">=0.8.3 <0.10.0",
+        "sockjs-client": "^1.4.0",
+        "type-fest": "^0.13.1",
+        "webpack": ">=4.43.0 <6.0.0",
+        "webpack-dev-server": "3.x",
+        "webpack-hot-middleware": "2.x",
+        "webpack-plugin-serve": "0.x || 1.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/webpack": {
+          "optional": true
+        },
+        "sockjs-client": {
+          "optional": true
+        },
+        "type-fest": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        },
+        "webpack-hot-middleware": {
+          "optional": true
+        },
+        "webpack-plugin-serve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -3387,6 +3453,15 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "dev": true,
+      "dependencies": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.18.0-next.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
@@ -3592,6 +3667,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/eslint/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/espree": {
@@ -5835,6 +5919,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/native-url": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/native-url/-/native-url-0.2.6.tgz",
+      "integrity": "sha512-k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==",
+      "dev": true,
+      "dependencies": {
+        "querystring": "^0.2.0"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6750,6 +6843,16 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
     },
+    "node_modules/react-refresh": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
+      "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -7655,6 +7758,12 @@
         "figgy-pudding": "^3.5.1"
       }
     },
+    "node_modules/stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
+      "dev": true
+    },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -8112,12 +8221,17 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -10395,6 +10509,12 @@
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
         }
       }
     },
@@ -10434,6 +10554,28 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
+      }
+    },
+    "@pmmmwh/react-refresh-webpack-plugin": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
+      "integrity": "sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==",
+      "dev": true,
+      "requires": {
+        "ansi-html": "^0.0.7",
+        "error-stack-parser": "^2.0.6",
+        "html-entities": "^1.2.1",
+        "native-url": "^0.2.6",
+        "schema-utils": "^2.6.5",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
       }
     },
     "@types/anymatch": {
@@ -12431,6 +12573,15 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "dev": true,
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "es-abstract": {
       "version": "1.18.0-next.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
@@ -12539,6 +12690,12 @@
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
           "dev": true
         }
       }
@@ -14405,6 +14562,15 @@
         "to-regex": "^3.0.1"
       }
     },
+    "native-url": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/native-url/-/native-url-0.2.6.tgz",
+      "integrity": "sha512-k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==",
+      "dev": true,
+      "requires": {
+        "querystring": "^0.2.0"
+      }
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -15160,6 +15326,13 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
+    },
+    "react-refresh": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
+      "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
+      "dev": true,
+      "peer": true
     },
     "readable-stream": {
       "version": "2.3.7",
@@ -15935,6 +16108,12 @@
         "figgy-pudding": "^3.5.1"
       }
     },
+    "stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
+      "dev": true
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -16316,10 +16495,12 @@
       }
     },
     "type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jakesidsmith/tsb",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jakesidsmith/tsb",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.12.7",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "devDependencies": {
     "@hot-loader/react-dom": "^16.14.0",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
     "@types/node": "^12.19.6",
     "@types/react": "^16.14.2",
     "@types/react-dom": "^16.9.10",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@babel/core": "^7.12.7",
     "@babel/preset-env": "^7.12.7",
+    "@types/babel__core": "^7.1.14",
     "@types/semver": "^7.3.4",
     "@types/webpack-dev-server": "^3.11.1",
     "babel-loader": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jakesidsmith/tsb",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Dead simple TypeScript bundler, watcher, dev server, transpiler, and polyfiller",
   "publishConfig": {
     "access": "public"

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,7 +97,7 @@ export interface Config {
     presets: readonly BabelPluginItem[],
     mode: Mode,
     command: Command
-  ) => readonly BabelPluginItem[];
+  ) => BabelPluginItem[];
   /**
    * @description Extend the babel plugins
    */
@@ -105,7 +105,7 @@ export interface Config {
     plugins: readonly BabelPluginItem[],
     mode: Mode,
     command: Command
-  ) => readonly BabelPluginItem[];
+  ) => BabelPluginItem[];
   /**
    * @description Extend the webpack plugins
    */
@@ -113,7 +113,7 @@ export interface Config {
     plugins: readonly WebpackPlugin[],
     mode: Mode,
     command: Command
-  ) => readonly WebpackPlugin[];
+  ) => WebpackPlugin[];
   /**
    * @description Extend the webpack module.rules
    */
@@ -121,7 +121,7 @@ export interface Config {
     rules: readonly WebpackModuleRule[],
     mode: Mode,
     command: Command
-  ) => readonly WebpackModuleRule[];
+  ) => WebpackModuleRule[];
 }
 
 export type Headers = Record<string, string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,7 +94,7 @@ export interface Config {
    * @description Extend the babel presets
    */
   extendBabelPresets?: (
-    presets: readonly BabelPluginItem[],
+    presets: BabelPluginItem[],
     mode: Mode,
     command: Command
   ) => BabelPluginItem[];
@@ -102,7 +102,7 @@ export interface Config {
    * @description Extend the babel plugins
    */
   extendBabelPlugins?: (
-    plugins: readonly BabelPluginItem[],
+    plugins: BabelPluginItem[],
     mode: Mode,
     command: Command
   ) => BabelPluginItem[];
@@ -110,7 +110,7 @@ export interface Config {
    * @description Extend the webpack plugins
    */
   extendWebpackPlugins?: (
-    plugins: readonly WebpackPlugin[],
+    plugins: WebpackPlugin[],
     mode: Mode,
     command: Command
   ) => WebpackPlugin[];
@@ -118,7 +118,7 @@ export interface Config {
    * @description Extend the webpack module.rules
    */
   extendWebpackModuleRules?: (
-    rules: readonly WebpackModuleRule[],
+    rules: WebpackModuleRule[],
     mode: Mode,
     command: Command
   ) => WebpackModuleRule[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,10 @@
-import { Configuration } from 'webpack';
+import {
+  Configuration,
+  Plugin as WebpackPlugin,
+  RuleSetRule as WebpackModuleRule,
+} from 'webpack';
 import { Configuration as DevServerConfiguration } from 'webpack-dev-server';
+import { PluginItem as BabelPluginItem } from '@babel/core';
 
 export interface Config {
   // Required
@@ -85,6 +90,38 @@ export interface Config {
    * @description Custom headers to send with dev server requests
    */
   headers?: Headers;
+  /**
+   * @description Extend the babel presets
+   */
+  extendBabelPresets?: (
+    presets: readonly BabelPluginItem[],
+    mode: Mode,
+    command: Command
+  ) => readonly BabelPluginItem[];
+  /**
+   * @description Extend the babel plugins
+   */
+  extendBabelPlugins?: (
+    plugins: readonly BabelPluginItem[],
+    mode: Mode,
+    command: Command
+  ) => readonly BabelPluginItem[];
+  /**
+   * @description Extend the webpack plugins
+   */
+  extendWebpackPlugins?: (
+    plugins: readonly WebpackPlugin[],
+    mode: Mode,
+    command: Command
+  ) => readonly WebpackPlugin[];
+  /**
+   * @description Extend the webpack module.rules
+   */
+  extendWebpackModuleRules?: (
+    rules: readonly WebpackModuleRule[],
+    mode: Mode,
+    command: Command
+  ) => readonly WebpackModuleRule[];
 }
 
 export type Headers = Record<string, string>;

--- a/test-files/tsb.config.ts
+++ b/test-files/tsb.config.ts
@@ -1,3 +1,4 @@
+import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import { Config } from '../src';
 
 const config: Config = {
@@ -12,7 +13,21 @@ const config: Config = {
   },
   publicDir: 'static',
   publicPath: '/static/',
-  reactHotLoading: true,
+  reactHotLoading: false,
+  extendBabelPlugins: (plugins, _mode, command) => {
+    if (command === 'serve') {
+      return [...plugins, require.resolve('react-refresh/babel')];
+    }
+
+    return plugins;
+  },
+  extendWebpackPlugins: (plugins, _mode, command) => {
+    if (command === 'serve') {
+      return [...plugins, new ReactRefreshWebpackPlugin()];
+    }
+
+    return plugins;
+  },
 };
 
 export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "noEmit": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "target": "ES2015",
     "moduleResolution": "Node",
     "module": "ESNext"


### PR DESCRIPTION
Relies on #22 

Adds the ability to extend the:
- Babel presets
- Babel plugins
- Webpack plugins
- Webpack module rules

Now uses the `./tsconfig.json` relative to the current working directory for parsing the `tsb.config.ts` (potentially breaking change)