### PR TITLE
Html template env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Out of the box tsb offers you:
 - Dead code elimination
 - Expose [environment variables](#environment-variables) and define defaults (with [webpack environment plugin](https://webpack.js.org/plugins/environment-plugin/))
 - Load environment variables from a `.env` file (with [dotenv](https://github.com/motdotla/dotenv))
+- Reference environment variables in your `index.html` template
 - Hot-loading
 - React hot-loading (with a little [extra setup](#react-hot-loading))
 - Bundle hashing

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ interface Config {
   tsconfigPath?: string; // Default: tsconfig.json in the root of the project
   // Path to a custom index.html template
   indexHTMLPath?: string;
+  // Variables to expose to the index.html template (referenced with <%= example %>)
+  indexHTMLEnv?: Record<string, any>;
   // List of commands for which to output index.html to disk
   outputIndexHTMLFor?: readonly ('build' | 'watch' | 'serve')[]; // Default: ['build', 'watch']
   // Whether to add script tag to body, head, or not at all

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jakesidsmith/tsb",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jakesidsmith/tsb",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.12.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2541,9 +2541,13 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001159",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
-      "integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA=="
+      "version": "1.0.30001241",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
+      "integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.0",
@@ -12070,9 +12074,9 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001159",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
-      "integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA=="
+      "version": "1.0.30001241",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
+      "integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ=="
     },
     "chalk": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jakesidsmith/tsb",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Dead simple TypeScript bundler, watcher, dev server, transpiler, and polyfiller",
   "publishConfig": {
     "access": "public"

--- a/src/config.ts
+++ b/src/config.ts
@@ -181,11 +181,43 @@ export const getTsbConfig = (configPath: string): Config => {
     if (missingEnvVars.length) {
       missingEnvVars.forEach((envVar) => {
         logger.error(
-          `Could not get value for environment variable "${envVar}"`
+          `Could not get value for environment variable "${envVar}" defined in config.env`
         );
       });
       return process.exit(1);
     }
+  }
+
+  let { indexHTMLEnv } = config;
+
+  if (indexHTMLEnv) {
+    const missingEnvVars = Object.entries(indexHTMLEnv)
+      .map(([key, value]) =>
+        typeof value === 'undefined' && typeof process.env[key] === 'undefined'
+          ? key
+          : null
+      )
+      .filter((key) => key !== null);
+
+    if (missingEnvVars.length) {
+      missingEnvVars.forEach((envVar) => {
+        logger.error(
+          `Could not get value for environment variable "${envVar}" defined in config.indexHTMLEnv`
+        );
+      });
+      return process.exit(1);
+    }
+
+    indexHTMLEnv = Object.entries(indexHTMLEnv).reduce((memo, [key]) => {
+      if (typeof process.env[key] !== 'undefined') {
+        return {
+          ...memo,
+          [key]: process.env[key],
+        };
+      }
+
+      return memo;
+    }, indexHTMLEnv);
   }
 
   if (config.indexHTMLPath) {
@@ -267,5 +299,8 @@ export const getTsbConfig = (configPath: string): Config => {
     }
   }
 
-  return config;
+  return {
+    ...config,
+    indexHTMLEnv,
+  };
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ const CONFIG_VALIDATOR = yup
     mainBundleName: yup.string().optional(),
     tsconfigPath: yup.string().optional(),
     indexHTMLPath: yup.string().optional(),
+    indexHTMLEnv: yup.object<Record<string, unknown>>().optional(),
     outputIndexHTMLFor: yup
       .array()
       .of<Command>(yup.mixed<Command>().oneOf(['build', 'watch', 'serve']))

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,10 @@ export interface Config {
    */
   indexHTMLPath?: string;
   /**
+   * @description Variables to expose to the index.html template (referenced with <%= example %>)
+   */
+  indexHTMLEnv?: Env;
+  /**
    * @description List of commands for which to output index.html to disk
    */
   outputIndexHTMLFor?: readonly Command[];

--- a/src/webpack-config.ts
+++ b/src/webpack-config.ts
@@ -34,6 +34,7 @@ export const createWebpackConfig = (
     mainBundleName = 'bundle',
     tsconfigPath = path.resolve(process.cwd(), 'tsconfig.json'),
     indexHTMLPath,
+    indexHTMLEnv = {},
     outputIndexHTMLFor = ['build', 'watch'],
     insertScriptTag = 'body',
     reactHotLoading = false,
@@ -96,6 +97,7 @@ export const createWebpackConfig = (
                   filename: path.resolve(fullOutDir, 'index.html'),
                   alwaysWriteToDisk: shouldOutputHTML,
                   inject: insertScriptTag,
+                  templateParameters: indexHTMLEnv,
                 }
               : {
                   alwaysWriteToDisk: shouldOutputHTML,
@@ -103,6 +105,7 @@ export const createWebpackConfig = (
                   meta: {
                     viewport: 'width=device-width, initial-scale=1',
                   },
+                  templateParameters: indexHTMLEnv,
                 }
           ),
           new HtmlWebpackHarddiskPlugin(),

--- a/test-files/src/index.html
+++ b/test-files/src/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" type="text/css" href="/static/css/styles.css" />
   </head>
   <body>
+    <h1><%= TEST %></h1>
     <div id="app"></div>
   </body>
 </html>

--- a/test-files/tsb.config.ts
+++ b/test-files/tsb.config.ts
@@ -9,7 +9,7 @@ const config: Config = {
   mainBundleName: 'index',
   indexHTMLPath: 'src/index.html',
   indexHTMLEnv: {
-    TEST: 'Hello, World!',
+    TEST: undefined,
   },
   tsconfigPath: 'tsconfig.test.json',
   env: {

--- a/test-files/tsb.config.ts
+++ b/test-files/tsb.config.ts
@@ -8,6 +8,9 @@ const config: Config = {
   mainOutSubDir: 'js',
   mainBundleName: 'index',
   indexHTMLPath: 'src/index.html',
+  indexHTMLEnv: {
+    TEST: 'Hello, World!',
+  },
   tsconfigPath: 'tsconfig.test.json',
   env: {
     TEST: undefined,


### PR DESCRIPTION
Allow defining an `indexHTMLEnv` object of variables to expose to the `index.html` template, accessed with `<%= exmaple %>` syntax.

This includes manually collecting env vars from the `process.env`/`.env` that were defined in the `indexHTMLEnv`.