### PR TITLE
Backward compatible script loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ interface Config {
   outputIndexHTMLFor?: readonly ('build' | 'watch' | 'serve')[]; // Default: ['build', 'watch']
   // Whether to add script tag to body, head, or not at all
   insertScriptTag?: 'body' | 'head' | false; // Default: 'body'
+  // Whether add "defer" attribute to script tag.
+  scriptLoading?: 'blocking' | 'defer' | 'module'; // default 'blocking'
   // Whether React hot-loading is enabled
   reactHotLoading?: boolean; // Default: false
   // List of commands for which output bundles are hashed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jakesidsmith/tsb",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jakesidsmith/tsb",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.12.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jakesidsmith/tsb",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Dead simple TypeScript bundler, watcher, dev server, transpiler, and polyfiller",
   "publishConfig": {
     "access": "public"

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,10 @@ export interface Config {
    */
   insertScriptTag?: InsertScriptTag;
   /**
+   * @description Whether add "defer" attribute to script tag.
+   */
+  scriptLoading?: 'blocking' | 'defer' | 'module';
+  /**
    * @description Whether React hot-loading is enabled
    */
   reactHotLoading?: boolean;

--- a/src/webpack-config.ts
+++ b/src/webpack-config.ts
@@ -37,6 +37,7 @@ export const createWebpackConfig = (
     indexHTMLEnv = {},
     outputIndexHTMLFor = ['build', 'watch'],
     insertScriptTag = 'body',
+    scriptLoading = 'blocking',
     reactHotLoading = false,
     hashFilesFor = ['build', 'watch'],
     additionalFilesToParse = [],
@@ -102,11 +103,13 @@ export const createWebpackConfig = (
                   filename: path.resolve(fullOutDir, 'index.html'),
                   alwaysWriteToDisk: shouldOutputHTML,
                   inject: insertScriptTag,
+                  scriptLoading,
                   templateParameters: indexHTMLEnv,
                 }
               : {
                   alwaysWriteToDisk: shouldOutputHTML,
                   inject: insertScriptTag,
+                  scriptLoading,
                   meta: {
                     viewport: 'width=device-width, initial-scale=1',
                   },


### PR DESCRIPTION
Due to unforeseen changes to html-webpack-plugin I am releasing a new major version that adds a new `scriptLoading` option, which now defaults to `blocking` - the same functionality as in v1.